### PR TITLE
Updating the angular dependencies 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
       "angular": "=1.4.9",
       "angular-route": "=1.4.9",
       "angular-resource": "=1.4.9",
-      "angular-ui-router": "v0.2.15"
+      "angular-ui-router": "=0.2.15"
     }
   },
   "vendor": {

--- a/bower.json
+++ b/bower.json
@@ -2,9 +2,9 @@
   "lib": {
     "name": "bower-rails generated lib assets",
     "dependencies": {
-      "angular": "v1.4.7",
-      "angular-route": "v1.4.x",
-      "angular-resource": "v1.4.8",
+      "angular": "=1.4.9",
+      "angular-route": "=1.4.9",
+      "angular-resource": "=1.4.9",
       "angular-ui-router": "v0.2.15"
     }
   },


### PR DESCRIPTION
updated the angular dependencies in bower.json so that all angular dependency version match. Uplifted angular to 1.4.9. I did not notice any immediate issues on the FE with the change in angular version.

The only breaking change can be found [here](https://github.com/angular/angular.js/blob/master/CHANGELOG.md#breaking-changes-2). However, I don't think this applies to us since I could not find an instance in the project where we are using a timeout to resolve a promise within a resource call.