### PR TITLE
update crime data to 2016 through 2019

### DIFF
--- a/lib/entities/crime.rb
+++ b/lib/entities/crime.rb
@@ -1,6 +1,6 @@
 module Entities
   class Crime < GeoJson
-    attr_accessor :ibrs, :description, :address, :from_date, :dataset_year, :source, :last_updated, :location_1
+    attr_accessor :ibrs,  :description, :address, :from_date, :dataset_year, :source, :last_updated, :location, :location_1
 
     def initialize(args)
       super(args)
@@ -23,7 +23,11 @@ module Entities
     end
 
     def geometry
-      location_1
+      if location.nil? 
+        location_1
+      else
+        location
+      end
     end
 
     def mappable?

--- a/lib/kcmo_datasets/crime.rb
+++ b/lib/kcmo_datasets/crime.rb
@@ -2,35 +2,31 @@ require 'socrata_client'
 require 'crime_mapper'
 
 module KcmoDatasets
-  REGULAR_DATASOURCE_2014 = 'yu5f-iqbp'
-  API_DATASOURCE_2014 = 'nsn9-g8a4'
 
-  REGULAR_DATASOURCE_2015 = 'kbzx-7ehe'
-  API_DATASOURCE_2015 = 'geta-wrqs'
+  LEGACY_LOCATION_FIELD = 'location_1'
+  NEW_LOCATION_FIELD = 'location'
 
   REGULAR_DATASOURCE_2016 = 'wbz8-pdv7'
   API_DATASOURCE_2016 = 'c6e8-258d'
 
+  REGULAR_DATASOURCE_2017 = '98is-shjt'
+  API_DATASOURCE_2017 = 'wy8a-bydn'
+
+  REGULAR_DATASOURCE_2018 = 'dmjw-d28i'
+  API_DATASOURCE_2018 = 'nyg5-tzkz'
+
+  REGULAR_DATASOURCE_2019 = 'pxaa-ahcm'
+  API_DATASOURCE_2019 = 'b9da-4mi6'
+
   class Crime
-    CRIME_SOURCE_2014_URI = 'https://data.kcmo.org/Crime/KCPD-Crime-Data-2014/yu5f-iqbp/'
-    CRIME_SOURCE_2015_URI = 'https://data.kcmo.org/Crime/KCPD-Crime-Data-2015/kbzx-7ehe/'
     CRIME_SOURCE_2016_URI = 'https://data.kcmo.org/Crime/KCPD-Crime-Data-2016/wbz8-pdv7/'
+    CRIME_SOURCE_2017_URI = 'https://data.kcmo.org/Crime/KCPD-Crime-Data-2017/98is-shjt/'
+    CRIME_SOURCE_2018_URI = 'https://data.kcmo.org/Crime/KCPD-Crime-Data-2018/dmjw-d28i/'
+    CRIME_SOURCE_2019_URI = 'https://data.kcmo.org/Crime/KCPD-Crime-Data-2018/pxaa-ahcm/'
 
     def initialize(neighborhood, options)
       @neighborhood = neighborhood
       @options = options
-    end
-
-    def fetch_metadata_2014
-      @metadata_2014 ||= JSON.parse(HTTParty.get('https://data.kcmo.org/api/views/nsn9-g8a4/').response.body)
-    rescue
-      {}
-    end
-
-    def fetch_metadata_2015
-      @metadata_2015 ||= JSON.parse(HTTParty.get('https://data.kcmo.org/api/views/geta-wrqs/').response.body)
-    rescue
-      {}
     end
 
     def fetch_metadata_2016
@@ -39,63 +35,102 @@ module KcmoDatasets
       {}
     end
 
+    def fetch_metadata_2017
+      @metadata_2017 ||= JSON.parse(HTTParty.get('https://data.kcmo.org/api/views/wy8a-bydn/').response.body)
+    rescue
+      {}
+    end
+
+    def fetch_metadata_2018
+      @metadata_2018 ||= JSON.parse(HTTParty.get('https://data.kcmo.org/api/views/nyg5-tzkz/').response.body)
+    rescue
+      {}
+    end
+
+    def fetch_metadata_2019
+      @metadata_2019 ||= JSON.parse(HTTParty.get('https://data.kcmo.org/api/views/b9da-4mi6/').response.body)
+    rescue
+      {}
+    end
+
     def query_data
+      puts '== trace -> query_data =='
+
       beginning_date = parse_date(@options[:start_date])
       end_date = parse_date(@options[:end_date])
 
       crime = []
 
       if beginning_date || end_date
-        if beginning_date.try(&:year) == 2014 || end_date.try(&:year) == 2014
-          crime << query(API_DATASOURCE_2014).each do |crime|
-            crime['dataset_year'] = 2014
-            crime['source'] = CRIME_SOURCE_2014_URI
-            crime['last_updated'] = fetch_metadata_2014['rowsUpdatedAt']
-          end
-        end
-
-        if beginning_date.try(&:year) == 2015 || end_date.try(&:year) == 2015
-          crime << query(API_DATASOURCE_2015).each do
-            crime['dataset_year'] = 2015
-            crime['source'] = CRIME_SOURCE_2015_URI
-            crime['last_updated'] = fetch_metadata_2015['rowsUpdatedAt']
-          end
-        end
-
         if beginning_date.try(&:year) == 2016 || end_date.try(&:year) == 2016
-          crime << query(API_DATASOURCE_2016).each do |crime|
+          crime << query(API_DATASOURCE_2016, LEGACY_LOCATION_FIELD).each do |crime|
             crime['dataset_year'] = 2016
             crime['source'] = CRIME_SOURCE_2016_URI
             crime['last_updated'] = fetch_metadata_2016['rowsUpdatedAt']
           end
         end
+
+        if beginning_date.try(&:year) == 2017 || end_date.try(&:year) == 2017
+          puts '== trace -> using 2017 in a crime query =='
+          crime << query(API_DATASOURCE_2017, LEGACY_LOCATION_FIELD).each do |crime|
+            crime['dataset_year'] = 2017
+            crime['source'] = CRIME_SOURCE_2017_URI
+            crime['last_updated'] = fetch_metadata_2017['rowsUpdatedAt']
+          end
+        end
+
+        if beginning_date.try(&:year) == 2018 || end_date.try(&:year) == 2018
+          puts '== trace -> using 2018 in a crime query =='
+          crime << query(API_DATASOURCE_2018, NEW_LOCATION_FIELD).each do |crime|
+            crime['dataset_year'] = 2018
+            crime['source'] = CRIME_SOURCE_2018_URI
+            crime['last_updated'] = fetch_metadata_2018['rowsUpdatedAt']
+          end
+        end
+
+        if beginning_date.try(&:year) == 2019 || end_date.try(&:year) == 2019
+          puts '== trace -> using 2019 in a crime query =='
+          crime << query(API_DATASOURCE_2019, NEW_LOCATION_FIELD).each do |crime|
+            crime['dataset_year'] = 2019
+            crime['source'] = CRIME_SOURCE_2019_URI
+            crime['last_updated'] = fetch_metadata_2019['rowsUpdatedAt']
+          end
+        end
+
       else
-        crime << query(API_DATASOURCE_2014).each do |crime|
-          crime['dataset_year'] = 2014
-          crime['source'] = CRIME_SOURCE_2014_URI
-          crime['last_updated'] = fetch_metadata_2014['rowsUpdatedAt']
-        end
-
-        crime << query(API_DATASOURCE_2015).each do |crime|
-          crime['dataset_year'] = 2015
-          crime['source'] = CRIME_SOURCE_2015_URI
-          crime['last_updated'] = fetch_metadata_2015['rowsUpdatedAt']
-        end
-
-        crime << query(API_DATASOURCE_2016).each do |crime|
+        crime << query(API_DATASOURCE_2016, LEGACY_LOCATION_FIELD).each do |crime|
           crime['dataset_year'] = 2016
           crime['source'] = CRIME_SOURCE_2016_URI
           crime['last_updated'] = fetch_metadata_2016['rowsUpdatedAt']
         end
+
+        crime << query(API_DATASOURCE_2017, LEGACY_LOCATION_FIELD).each do |crime|
+          crime['dataset_year'] = 2017
+          crime['source'] = CRIME_SOURCE_2017_URI
+          crime['last_updated'] = fetch_metadata_2017['rowsUpdatedAt']
+        end
+
+        crime << query(API_DATASOURCE_2018, NEW_LOCATION_FIELD).each do |crime|
+          crime['dataset_year'] = 2018
+          crime['source'] = CRIME_SOURCE_2018_URI
+          crime['last_updated'] = fetch_metadata_2018['rowsUpdatedAt']
+        end
+
+        crime << query(API_DATASOURCE_2019, NEW_LOCATION_FIELD).each do |crime|
+          crime['dataset_year'] = 2019
+          crime['source'] = CRIME_SOURCE_2019_URI
+          crime['last_updated'] = fetch_metadata_2019['rowsUpdatedAt']
+        end
+
       end
 
       crime.flatten
     end
 
     def grouped_totals
-      query = "SELECT ibrs, count(ibrs) WHERE #{@neighborhood.within_polygon_query('location_1')} GROUP BY ibrs"
+      query = "SELECT ibrs, count(ibrs) WHERE #{@neighborhood.within_polygon_query('location')} GROUP BY ibrs"
 
-      crimes = SocrataClient.get(API_DATASOURCE_2016, query)
+      crimes = SocrataClient.get(API_DATASOURCE_2018, query)
 
       crime_counts = crimes.inject({}) {|crime_hash, crime|
         crime_hash.merge(crime['ibrs'] => crime['count_ibrs'])
@@ -106,12 +141,13 @@ module KcmoDatasets
 
     private
 
-    def query(data_source)
-      SocrataClient.get(data_source, build_socrata_query)
+    def query(data_source, location_field)
+      puts '== entering query =='
+      SocrataClient.get(data_source, build_socrata_query(location_field))
     end
 
-    def build_socrata_query
-      query = "SELECT * WHERE #{@neighborhood.within_polygon_query('location_1')}"
+    def build_socrata_query(location_field_name)
+      query = "SELECT * WHERE #{@neighborhood.within_polygon_query(location_field_name)}"
 
       beginning_date = parse_date(@options[:start_date])
       end_date = parse_date(@options[:end_date])


### PR DESCRIPTION
Modified the code to move the crime data "window" to cover the current year - 3. Prior to the change, only 2014-2016 could be queried through the crime tab in the UI. 
Some additional changes were necessary to handle a key field name change - location_1->location - that occurred beginning in 2018.